### PR TITLE
Refactor submit endpoint parameters

### DIFF
--- a/app/api/puzzle/submit/route.ts
+++ b/app/api/puzzle/submit/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: NextRequest) {
   }
 
   const { successStr, themeGroupStr, timeStr } = await req.json();
-  const puzzle = JSON.parse(activePuzzle.puzzle) as Puzzle
+  const puzzle = JSON.parse(activePuzzle.puzzle) as Puzzle;
   const success = successStr as boolean;
   const themeGroup = themeGroupStr as string[];
   const group = themeGroup.length > 0 ? toGroupId(themeGroup) : undefined;

--- a/app/api/puzzle/submit/route.ts
+++ b/app/api/puzzle/submit/route.ts
@@ -6,6 +6,7 @@ import { RatingColl } from '../../../../models/RatingColl';
 import {
   DEFAULT_RATING,
   Rating,
+  getExistingUserRating,
   getThemeRatings,
 } from '@/src/rating/getRating';
 import { UserThemeColl } from '@/models/UserThemeColl';
@@ -17,21 +18,14 @@ import { toGroupId } from '@/lib/utils';
 import { TimeThemeColl } from '@/models/TimeThemeColl';
 import updateAndScaleRatings from '@/src/rating/RatingCalculator';
 
+const MILLISECONDS_IN_SECOND = 1000;
+
 export async function POST(req: NextRequest) {
   await dbConnect();
   const { user } = await validateRequest();
   if (!user) {
     return new Response('Unauthorized', { status: 401 });
   }
-
-  // TODO: Remove these things!
-  const { puzzle_, success_, prv_, themeGroupStr, time } = await req.json();
-  const puzzle = puzzle_ as Puzzle;
-  const success = success_ as boolean;
-  const userRating = prv_ as Rating;
-  const themeGroup = themeGroupStr as string[];
-  const group = themeGroup.length > 0 ? toGroupId(themeGroup) : undefined;
-  const t = (time as number) / 1000;
 
   // Delete active puzzle, as it is solved.
   const activePuzzle = await ActivePuzzleColl.findOneAndDelete({
@@ -40,6 +34,18 @@ export async function POST(req: NextRequest) {
   if (!activePuzzle) {
     throw new Error('No active puzzle found - something is wrong!');
   }
+
+  const { successStr, themeGroupStr, timeStr } = await req.json();
+  const puzzle = JSON.parse(activePuzzle.puzzle) as Puzzle
+  const success = successStr as boolean;
+  const themeGroup = themeGroupStr as string[];
+  const group = themeGroup.length > 0 ? toGroupId(themeGroup) : undefined;
+  const totalTime = (timeStr as number) / MILLISECONDS_IN_SECOND;
+  const userRating = await getExistingUserRating(user);
+  const moves = puzzle.Moves.split(' ').length / 2;
+  const timePerMove = totalTime / moves;
+  console.log(`Time per move : ${timePerMove}`);
+
   updateAndScaleRatings(userRating, puzzle, success, activePuzzle.isReview);
 
   // Update user's rating.
@@ -57,9 +63,9 @@ export async function POST(req: NextRequest) {
     : puzzle;
 
   if (group) {
-    await updateThemedLeitner(user, reviewee, success, group, t);
+    await updateThemedLeitner(user, reviewee, success, group, timePerMove);
   } else {
-    await updateLeitner(user, reviewee, success, t);
+    await updateLeitner(user, reviewee, success, timePerMove);
   }
 
   // NB: We don't filter out irrelevant themes here. Even if theme is irrelevant, we compute ratings and
@@ -76,13 +82,11 @@ export async function POST(req: NextRequest) {
       { $set: themeRating },
       { upsert: true } // Insert if not found.
     );
-    const moves = puzzle.Moves.split(' ').length / 2;
-    console.log(`\t\tTime per move : ${t / moves}`);
     if (success) {
       await TimeThemeColl.updateOne(
         { username: user.username, theme: theme },
         {
-          $set: { time: t / moves },
+          $set: { time: timePerMove },
         },
         { upsert: true }
       );

--- a/components/puzzle-ui/puzzle-board.tsx
+++ b/components/puzzle-ui/puzzle-board.tsx
@@ -16,9 +16,6 @@ import RatingComponent from './controls/rating';
 import DisplayBox from './controls/display-box';
 import useTimer from '@/hooks/useTimer';
 import { Rating } from '@/src/rating/getRating';
-import { Button } from '../ui/button';
-import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
-import StaticBoard from './static-board';
 import PuzzleHintBox from './controls/puzzle-hint';
 
 interface PuzzleBoardProps {
@@ -139,7 +136,7 @@ const PuzzleBoard: React.FC<PuzzleBoardProps> = ({
   /** HANDLE PLAYER MOVE VERIFICATION */
   function undoWrongMove() {
     if (submitPuzzle && !wrong) {
-      submitPuzzle(false, rating, 0).then((r) => setRating(r));
+      submitPuzzle(false, 0).then((r) => setRating(r));
       setWrong(true);
     }
     game.undo();
@@ -161,7 +158,7 @@ const PuzzleBoard: React.FC<PuzzleBoardProps> = ({
     stopTimer();
     if (submitPuzzle && !wrong) {
       const elapsed = time;
-      submitPuzzle(true, rating, elapsed).then((r) => setRating(r));
+      submitPuzzle(true, elapsed).then((r) => setRating(r));
     }
     setSolved(true);
   }
@@ -185,11 +182,10 @@ const PuzzleBoard: React.FC<PuzzleBoardProps> = ({
   const viewSolution = () => {
     if (rendered && !solved) {
       if (!wrong) {
-        submitPuzzle(false, rating, 0).then((r) => setRating(r));
+        submitPuzzle(false, 0).then((r) => setRating(r));
       }
       stopTimer();
       setWrong(true);
-      const elapsed = time;
       setSolved(true);
       setGaveUp(true);
 

--- a/components/puzzle-ui/puzzle-mode.tsx
+++ b/components/puzzle-ui/puzzle-mode.tsx
@@ -15,12 +15,11 @@ interface PuzzleModeProps {
 export const PuzzleContext = React.createContext({
   submitNextPuzzle: (
     _success: boolean,
-    _prv: Rating,
     _time: number
   ): Promise<Rating> => {
     throw new Error();
   },
-  getNextPuzzle: () => {},
+  getNextPuzzle: () => { },
 });
 
 const NoPuzzles = (
@@ -69,17 +68,14 @@ const PuzzleMode: React.FC<PuzzleModeProps> = ({
   // submit the puzzle success/failure to the server
   const submitNextPuzzle = (
     success: boolean,
-    prv: Rating,
     time: number
   ): Promise<Rating> =>
     fetch(`/api/puzzle/submit`, {
       method: 'POST',
       body: JSON.stringify({
-        puzzle_: puzzle,
-        success_: success,
-        prv_: prv,
+        successStr: success,
         themeGroupStr: group,
-        time: time,
+        timeStr: time,
       }),
     })
       .then((response) => response.text())

--- a/components/puzzle-ui/puzzle-mode.tsx
+++ b/components/puzzle-ui/puzzle-mode.tsx
@@ -13,13 +13,10 @@ interface PuzzleModeProps {
 }
 
 export const PuzzleContext = React.createContext({
-  submitNextPuzzle: (
-    _success: boolean,
-    _time: number
-  ): Promise<Rating> => {
+  submitNextPuzzle: (_success: boolean, _time: number): Promise<Rating> => {
     throw new Error();
   },
-  getNextPuzzle: () => { },
+  getNextPuzzle: () => {},
 });
 
 const NoPuzzles = (
@@ -66,10 +63,7 @@ const PuzzleMode: React.FC<PuzzleModeProps> = ({
   }, [puzzle]);
 
   // submit the puzzle success/failure to the server
-  const submitNextPuzzle = (
-    success: boolean,
-    time: number
-  ): Promise<Rating> =>
+  const submitNextPuzzle = (success: boolean, time: number): Promise<Rating> =>
     fetch(`/api/puzzle/submit`, {
       method: 'POST',
       body: JSON.stringify({

--- a/components/woodpecker/woodpecker-mode.tsx
+++ b/components/woodpecker/woodpecker-mode.tsx
@@ -22,9 +22,8 @@ const WoodPeckerMode: React.FC<WoodpeckerModeProps> = ({
 
   const submitNextPuzzle = (
     _success: boolean,
-    _prv: Rating,
-    _t: number
-  ): Promise<Rating> => Promise.resolve(_prv);
+    _time: number
+  ): Promise<Rating> => Promise.resolve(initialRating);
 
   const getNextPuzzle = () => {
     if (puzzles.length === 1) {

--- a/src/LeitnerIntance.ts
+++ b/src/LeitnerIntance.ts
@@ -7,9 +7,9 @@ import { User } from 'lucia';
 const BOX_A_PROB: number = 0.8;
 const BOX_LIMIT: number = 50;
 
-// If the user solves a puzzle in Box A in < 3 seconds, we can remove it
+// If the user solves a puzzle in Box A in < 2 seconds per move, we can remove it
 // immediately from system (i.e. promote it twice).
-const TIME_THRESHOLD: number = 3;
+const TIME_THRESHOLD: number = 2;
 
 interface LeitnerInstance {
   boxA: Array<Puzzle>;


### PR DESCRIPTION
Dependent on #66.

We anyway retrieve the puzzle from `ActiveColl`, and we should be retrieving the `Rating` from the DB instead of passing it from the front-end (which may cause lost updates).

I think it makes sense for `submit` to only take whether the active puzzle was solved successfully and the time the user took if so.